### PR TITLE
add cd2 value to gem GA middleware

### DIFF
--- a/gem/tests/test_middleware.py
+++ b/gem/tests/test_middleware.py
@@ -106,20 +106,25 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             password='tester')
         self.client.login(username='tester', password='tester')
         self.user.profile.gender = 'f'
+
         self.user.profile.save()
 
-        request = RequestFactory().get('/', HTTP_HOST='localhost')
+        request = RequestFactory().get(
+            '/',
+            HTTP_HOST='localhost',
+            HTTP_X_DCMGUID="0000-000-01",
+        )
         request.site = self.main.get_site()
         request.user = self.user
         middleware = GemMoloGoogleAnalyticsMiddleware()
         middleware.submit_to_local_account(
             request, self.response, self.site_settings)
-
+        cd1 = middleware.get_visitor_id(request)
         mock_submit_tracking.assert_called_once_with(
             'local_ga_tracking_code',
             request,
             self.response,
-            {'cd2': self.user.profile.uuid})
+            {'cd2': self.user.profile.uuid, 'cd1': cd1})
 
     @patch(submit_tracking_method)
     def test_submit_to_local_ga__ignored_info(self, mock_submit_tracking):

--- a/gem/tests/test_middleware.py
+++ b/gem/tests/test_middleware.py
@@ -42,7 +42,11 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
         the additional GA account.
         '''
 
-        request = RequestFactory().get('/', HTTP_HOST='bbm.localhost')
+        request = RequestFactory().get(
+            '/',
+            HTTP_HOST='bbm.localhost',
+            HTTP_X_DCMGUID="0000-000-01"
+        )
         request.site = self.main.get_site()
 
         middleware = GemMoloGoogleAnalyticsMiddleware()
@@ -50,7 +54,8 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             request, self.response, self.site_settings)
 
         mock_submit_tracking.assert_called_once_with(
-            'bbm_tracking_code', request, self.response, {})
+            'bbm_tracking_code',
+            request, self.response, {'cd1': "0000-000-01"})
 
     @patch(submit_tracking_method)
     def test_submit_to_bbm_analytics_if_cookie_set(self, mock_submit_tracking):
@@ -60,7 +65,11 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
         should be sent to the additional GA account.
         '''
 
-        request = RequestFactory().get('/', HTTP_HOST='localhost')
+        request = RequestFactory().get(
+            '/',
+            HTTP_HOST='localhost',
+            HTTP_X_DCMGUID="0000-000-01"
+        )
         request.COOKIES['bbm'] = 'true'
         request.site = self.main.get_site()
 
@@ -69,7 +78,8 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             request, self.response, self.site_settings)
 
         mock_submit_tracking.assert_called_once_with(
-            'bbm_tracking_code', request, self.response, {})
+            'bbm_tracking_code',
+            request, self.response, {'cd1': "0000-000-01"})
 
     @patch(submit_tracking_method)
     def test_submit_to_local_ga_account(self, mock_submit_tracking):
@@ -80,7 +90,10 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
         the local GA account, not the additional GA account.
         '''
 
-        request = RequestFactory().get('/', HTTP_HOST='localhost')
+        request = RequestFactory().get(
+            '/',
+            HTTP_HOST='localhost',
+            HTTP_X_DCMGUID="0000-000-01",)
         request.site = self.main.get_site()
 
         middleware = GemMoloGoogleAnalyticsMiddleware()
@@ -88,7 +101,11 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             request, self.response, self.site_settings)
 
         mock_submit_tracking.assert_called_once_with(
-            'local_ga_tracking_code', request, self.response, {})
+            'local_ga_tracking_code',
+            request,
+            self.response,
+            {'cd1': "0000-000-01"}
+        )
 
     @patch(submit_tracking_method)
     def test_submit_to_local_ga_account__custom_params(self,
@@ -183,6 +200,7 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
         request = RequestFactory().get(
             '/search/?q=whatislife',
             HTTP_HOST='localhost',
+            HTTP_X_DCMGUID="0000-000-01"
         )
         request.site = self.main.get_site()
 
@@ -191,4 +209,6 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             request, self.response)
         # a normal response should activate GA tracking
         mock_submit_tracking.assert_called_once_with(
-            'local_ga_tracking_code', request, self.response, {})
+            'local_ga_tracking_code',
+            request, self.response,
+            {'cd1': "0000-000-01"})


### PR DESCRIPTION
adding a cd2 field for gem, this is generated the same way that the cid filed is generated in a django-google-analytics. 