### PR TITLE
add GA tracking for cd3 user type

### DIFF
--- a/gem/middleware.py
+++ b/gem/middleware.py
@@ -91,6 +91,11 @@ class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
                 and request.user.profile.uuid:
             custom_params.update({'cd2': request.user.profile.uuid})
 
+        if hasattr(request, 'user') and request.user.is_authenticated:
+            custom_params.update({'cd3': 'Registered'})
+        else:
+            custom_params.update({'cd3': 'Visitor'})
+
         if bbm_ga_code and should_submit_to_bbm_account:
             return self.submit_tracking(
                 bbm_ga_code,
@@ -111,6 +116,11 @@ class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
         custom_params = {}
         cd1 = self.get_visitor_id(request)
         custom_params.update({'cd1': cd1})
+        if hasattr(request, 'user') and request.user.is_authenticated:
+            custom_params.update({'cd3': 'Registered'})
+        else:
+            custom_params.update({'cd3': 'Visitor'})
+
         if site_settings.global_ga_tracking_code:
             if hasattr(request, 'user') and hasattr(request.user, 'profile')\
                     and request.user.profile.uuid:

--- a/gem/tests/test_middleware.py
+++ b/gem/tests/test_middleware.py
@@ -55,7 +55,7 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
 
         mock_submit_tracking.assert_called_once_with(
             'bbm_tracking_code',
-            request, self.response, {'cd1': "0000-000-01"})
+            request, self.response, {"cd3": 'Visitor', 'cd1': "0000-000-01"})
 
     @patch(submit_tracking_method)
     def test_submit_to_bbm_analytics_if_cookie_set(self, mock_submit_tracking):
@@ -79,7 +79,7 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
 
         mock_submit_tracking.assert_called_once_with(
             'bbm_tracking_code',
-            request, self.response, {'cd1': "0000-000-01"})
+            request, self.response, {"cd3": 'Visitor', 'cd1': "0000-000-01"})
 
     @patch(submit_tracking_method)
     def test_submit_to_local_ga_account(self, mock_submit_tracking):
@@ -104,7 +104,7 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             'local_ga_tracking_code',
             request,
             self.response,
-            {'cd1': "0000-000-01"}
+            {"cd3": 'Visitor', 'cd1': "0000-000-01"}
         )
 
     @patch(submit_tracking_method)
@@ -141,7 +141,7 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
             'local_ga_tracking_code',
             request,
             self.response,
-            {'cd2': self.user.profile.uuid, 'cd1': cd1})
+            {"cd3": 'Registered', 'cd2': self.user.profile.uuid, 'cd1': cd1})
 
     @patch(submit_tracking_method)
     def test_submit_to_local_ga__ignored_info(self, mock_submit_tracking):
@@ -211,4 +211,4 @@ class TestCustomGemMiddleware(TestCase, GemTestCaseMixin):
         mock_submit_tracking.assert_called_once_with(
             'local_ga_tracking_code',
             request, self.response,
-            {'cd1': "0000-000-01"})
+            {"cd3": 'Visitor', 'cd1': "0000-000-01"})


### PR DESCRIPTION
Send user type through to GA on page views using the `cd3` parameter. User type is either 'Visitor' or 'Registered' and can probably be discerned by the presence of a user id

As per spreadsheet here https://docs.google.com/spreadsheets/d/1KxhugbJa4F0NCJD7R0Zp3VO8mIw-_tz2HFCRlslXXZs

The cd3 parameter is project specific and should probably be populated in the Gem middleware.****