### PR TITLE
check if nav_tags are of nonetype before iterating through them

### DIFF
--- a/gem/middleware.py
+++ b/gem/middleware.py
@@ -72,9 +72,10 @@ class GemMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
                 tags_str = ""
                 qs = load_tags_for_article(
                     {'locale_code': 'en', 'request': request}, page)
-                for q in qs:
-                    tags_str += "|" + q.title
-                return tags_str[1:]
+                if qs:
+                    for q in qs:
+                        tags_str += "|" + q.title
+                    return tags_str[1:]
         except Http404:
             return ""
 


### PR DESCRIPTION
load_article_tags returns Nonetype for footer page nav_tags.
See the following sentry error log: https://sentry.io/share/issue/61aa6bf097b5416c94c61aed7da8cef2/