### PR TITLE
Add submit comment via ajax for chhaa jaa

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -182,9 +182,6 @@ MIDDLEWARE_CLASSES += [
 
 
 # Template configuration
-
-# We have multiple layouts: use `base`, `malawi` , `springster` or `rwanda`
-# to switch between them.
 def get_default_template(site_layout_base, site_layout):
     return {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -216,6 +213,9 @@ def get_default_template(site_layout_base, site_layout):
     }
 
 
+# We have multiple layouts: use `base`, `malawi` , `springster`, `rwanda`
+# 'chhaajaa' or 'yegna'
+# Change SITE_LAYOUT_BASE to switch between them.
 SITE_LAYOUT_BASE = environ.get('SITE_LAYOUT_BASE', 'base')
 SITE_LAYOUT_2 = environ.get('SITE_LAYOUT_2', '')
 

--- a/gem/templates/chhaajaa/comments/comment_block.html
+++ b/gem/templates/chhaajaa/comments/comment_block.html
@@ -8,14 +8,6 @@
       {% if article.allow_commenting %}
         {% if request.user.is_authenticated %}
           {% render_comment_form for article %}
-          {% comment %}<!--
-          {% else %}
-            PREVIOUS URL<a href="{% url LOGIN_URL %}?next={{request.path}}"></a>
-            <a href="{% url LOGIN_URL %}" class="call-to-action__button call-to-action__button--primary">
-              {% trans "Log in to comment" %}
-            </a>
-            -->
-          {% endcomment %}
         {% endif %}
       {% else %}
         <h4 class="heading__title">

--- a/gem/templates/chhaajaa/comments/form.html
+++ b/gem/templates/chhaajaa/comments/form.html
@@ -1,5 +1,5 @@
 {% with article as article %}
-  <form method="post" action="{% url 'molo.commenting:molo-comments-post' %}#comments-list">
+  <form method="post" id="comment-form" action="{% url 'molo.commenting:molo-comments-post' %}">
   {% csrf_token %}
     <div class="form-group{% if form.comment.errors %} input-error {% endif %}">
     {% if form.errors %}
@@ -16,3 +16,20 @@
     <input type="hidden" name="next" value="{{ request.path|urlencode }}" />
   </form>
 {% endwith %}
+
+<script type="text/javascript">
+  $(document).ready(function() {
+        $('#comment-form').submit(function() {
+            $.ajax({
+              data: $(this).serialize(),
+              type: $(this).attr('method'),
+              url: $(this).attr('action'),
+              success: function (data) {
+                // if the comment was a success, remove the comment text from the text area
+                $('#id_comment').val('');
+              },
+            });
+            return false;
+        });
+    });
+</script>


### PR DESCRIPTION
This PR overrides the submit call for a comment within the Chhaa Jaa template and submits the comment via ajax. If the comment was submitted successfully it removes the comment text from the comment text area. Since Chhaa Jaa only recevies comments and does not display it anywhere, no further work is needed.