### PR TITLE
WWW resolve for springster sites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG MOLO_VERSION=7
 FROM praekeltfoundation/molo-bootstrap:${MOLO_VERSION}-onbuild
 
+COPY site-redir-www-nonwww.conf /etc/nginx/conf.d/site-redir-www-nonwww.conf
+
 ENV DJANGO_SETTINGS_MODULE=gem.settings.docker \
     CELERY_APP=gem
 

--- a/site-redir-www-nonwww.conf
+++ b/site-redir-www-nonwww.conf
@@ -1,0 +1,7 @@
+# redirect all requests with the prefix www. to the site without www
+server {
+    listen 80;
+    server_name ~^www\.(?<domain>.+)$;
+    return 301 http://$domain$request_uri;
+}
+

--- a/site-redir-www-nonwww.conf
+++ b/site-redir-www-nonwww.conf
@@ -2,6 +2,6 @@
 server {
     listen 80;
     server_name ~^www\.(?<domain>.+)$;
-    return 301 http://$domain$request_uri;
+    return 301 $scheme://$domain$request_uri;
 }
 


### PR DESCRIPTION
WWW resolve All sites hosted for Girl Effect should resolve to the main site landing on i.e za.heyspringster.com, www should revert to that.