### PR TITLE
Update the comment's view's page title to flag that it's a tile

### DIFF
--- a/gem/templates/base/comments/comments.html
+++ b/gem/templates/base/comments/comments.html
@@ -1,6 +1,6 @@
 {% extends "core/article_page.html" %}
 {% load wagtailcore_tags mptt_tags %}
-
+{% block title %}{% trans "Comments" %} - {{ self.title}}{% endblock %}
 {% block content %}
   <div class="comments comments{{self.get_parent_section.get_effective_extra_style_hints}}">
       <h1 class="heading comments__reply-heading">{% trans "Comments" %}</h1>

--- a/gem/templates/rwanda/comments/comments.html
+++ b/gem/templates/rwanda/comments/comments.html
@@ -1,5 +1,6 @@
 {% extends "core/article_page.html" %}
 {% load wagtailcore_tags mptt_tags molo_commenting_tags gem_tags %}
+{% block title %}{% trans "Comments" %} - {{ self.title}}{% endblock %}
 {% block content %}
 <div class="comments__container {% if self.get_parent_section.get_effective_extra_style_hints %}comments__container--{{self.get_parent_section.get_effective_extra_style_hints}}{% endif %}">
   <div class="breadcrumbs breadcrumbs--comments">

--- a/gem/templates/springster/comments/comments.html
+++ b/gem/templates/springster/comments/comments.html
@@ -1,5 +1,6 @@
 {% extends "core/article_page.html" %}
 {% load wagtailcore_tags mptt_tags molo_commenting_tags gem_tags %}
+{% block title %}Comments - {{ self.title}}{% endblock %}
 {% block content %}
 <div class="call-to-action call-to-action--wide-back">
   <a href="{% pageurl self.specific %}" class="call-to-action__nav-item-text call-to-action__nav-item-text--left">

--- a/gem/templates/springster/comments/comments.html
+++ b/gem/templates/springster/comments/comments.html
@@ -1,6 +1,6 @@
 {% extends "core/article_page.html" %}
 {% load wagtailcore_tags mptt_tags molo_commenting_tags gem_tags %}
-{% block title %}Comments - {{ self.title}}{% endblock %}
+{% block title %}{% trans "Comments" %} - {{ self.title}}{% endblock %}
 {% block content %}
 <div class="call-to-action call-to-action--wide-back">
   <a href="{% pageurl self.specific %}" class="call-to-action__nav-item-text call-to-action__nav-item-text--left">


### PR DESCRIPTION
When viewing the comments of an article page, thecomments page tile is the same as that of the article page. For example: http://za.heyspringster.com/sections/my-life/do-you-feel-alone-in-the-world/ has the same page title as it’s comments view: http://za.heyspringster.com/commenting/molo/48/comments/

This is causing a problem for web crawlers.

Proposed solution:
Add ‘Comments -’ at the beginning of the page title when the comments are being displayed
