### PR TITLE
fix logical error in regex

### DIFF
--- a/site-redir-www-nonwww.conf
+++ b/site-redir-www-nonwww.conf
@@ -1,7 +1,7 @@
 # redirect all requests with the prefix www. to the site without www
 server {
     listen 8000;
-    server_name ~^www\.(?<domain>.+)$;
+    server_name ~^www\.(?<domain>)$;
     return 301 $scheme://$domain$request_uri;
 }
 


### PR DESCRIPTION
https://www.site.com not redirecting to https://site.com
Period sufix in regex is not part of uri, domain kwarg should sufficient