### PR TITLE
Add rest_framework to installed apps

### DIFF
--- a/gem/settings/base.py
+++ b/gem/settings/base.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django_extensions',
     'django_prometheus',
+    'rest_framework',
 
     'allauth',
     'allauth.account',


### PR DESCRIPTION
Add rest framework so that the templates are used when interacting with the api via a browser.